### PR TITLE
Added a WebGoat directory for example attack files for WebGoat lessions + stub example 

### DIFF
--- a/examples/webgoat/vuln-00/README.md
+++ b/examples/webgoat/vuln-00/README.md
@@ -10,22 +10,33 @@ This test assumes 3 things:
 
 (1) That jerry-curl and jq are installed and available on the $PATH and uses the generic command-line attack.  To install these run the following command on Debian-based systems aka those using .deb packages.
 
+```
 $ sudo apt-get install owasp-wte-jerry-curl owasp-wte-jq
+```
 
 This assumes you have the OWASP WTE repo setup on the computer running Gauntlt.  If not, it can be added with:
+
+```
 $ sudo echo "deb http://appseclive.org/apt/14.04 trusty main" > /etc/apt/sources.list.d/owasp-wte.list
 $ sudo wget -q -O - http://appseclive.org/apt/owasp-wte.gpg.key | apt-key add -
+```
 
 (2) The script ./webgoat/vuln-00/vuln-00-runner is in the path aka $PATH  This can be done & confirmed with:
+
+```
 $ sudo cp webgoat/vuln-00/vuln-00-runner /usr/bin/
 $ sudo chmod 775 /usr/bin/vuln-00-runner 
-$ sudo which vuln-00-runner
+$ which vuln-00-runner
 /usr/bin/vuln-00-runner
+```
 
 (3) There is a local proxy running on 127.0.0.1:8888
 
 Testing vuln-00 can be done outside of Gauntlt by navigating to the webgoat/vuln-00 directory and running:
+
+```
 $ ./exploit-vuln-00.bash
+```
 
 This Gauntlt test was written by Matt Tesauro (matt.tesauro@owasp.org) on Mon, 23 Nov 2015 22:43:10 -0600
 

--- a/examples/webgoat/vuln-00/README.md
+++ b/examples/webgoat/vuln-00/README.md
@@ -1,0 +1,31 @@
+TEST vuln-00.attack
+
+This is a Gauntlt test to check if the vulnerability in WebGoat located at General => Http Basics (vuln-00) exists.
+
+It will return a
+ - 1 (error) if the vulnerability is present
+ - 0 (success) if the vulnerability is fixed (aka not present)
+
+This test assumes 3 things:
+
+(1) That jerry-curl and jq are installed and available on the $PATH and uses the generic command-line attack.  To install these run the following command on Debian-based systems aka those using .deb packages.
+
+$ sudo apt-get install owasp-wte-jerry-curl owasp-wte-jq
+
+This assumes you have the OWASP WTE repo setup on the computer running Gauntlt.  If not, it can be added with:
+$ sudo echo "deb http://appseclive.org/apt/14.04 trusty main" > /etc/apt/sources.list.d/owasp-wte.list
+$ sudo wget -q -O - http://appseclive.org/apt/owasp-wte.gpg.key | apt-key add -
+
+(2) The script ./webgoat/vuln-00/vuln-00-runner is in the path aka $PATH  This can be done & confirmed with:
+$ sudo cp webgoat/vuln-00/vuln-00-runner /usr/bin/
+$ sudo chmod 775 /usr/bin/vuln-00-runner 
+$ sudo which vuln-00-runner
+/usr/bin/vuln-00-runner
+
+(3) There is a local proxy running on 127.0.0.1:8888
+
+Testing vuln-00 can be done outside of Gauntlt by navigating to the webgoat/vuln-00 directory and running:
+$ ./exploit-vuln-00.bash
+
+This Gauntlt test was written by Matt Tesauro (matt.tesauro@owasp.org) on Mon, 23 Nov 2015 22:43:10 -0600
+

--- a/examples/webgoat/vuln-00/exploit-vuln-00.bash
+++ b/examples/webgoat/vuln-00/exploit-vuln-00.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+## Pretend this is a working Bash script - for now, this is just a shell
+## For my money, I'd actually write this in Python or Ruby
+## So consider this pseudo-code for now
+
+# --[ STEP 00 ]--
+# Request login page
+
+# --[ STEP 01 ]--
+# Log into WebGoat
+
+# --[ STEP 02 ]--
+# Figure out which menu item is "Http Basics"
+
+# --[ STEP 3 ]--
+# Request the lesson for General => Http Basics
+
+# --[ STEP 4 ]--
+# Submit the attack to the General => Http Basics page
+ATTACK=`echo -n "1"`
+
+# Purposefully fail for testing purposes
+#ATTACK=`echo -n "1"`
+
+# --[ STEP 6 ]--
+# Set the correct exit code
+# It will return a
+# - 0 (error) if the vulnerability is present
+# - 1 (success) if the vulnerability is fixed (aka not present)
+
+if [ $ATTACK -eq 1 ]
+then
+    # Attack successful
+    echo "Attack Successful"
+    exit 1
+else
+    # Attack failed - no vuln-00 present
+    echo "vuln-00 not present"
+    exit 0
+fi

--- a/examples/webgoat/vuln-00/vuln-00-runner
+++ b/examples/webgoat/vuln-00/vuln-00-runner
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Change the PWD to where the test files are located
+cd /home/hacker/webgoat/vuln-00/
+
+# And then run the test script
+./exploit-vuln-00.bash

--- a/examples/webgoat/vuln-00/vuln-00.attack
+++ b/examples/webgoat/vuln-00/vuln-00.attack
@@ -1,0 +1,11 @@
+@final
+Feature: hello world with gauntlt using the generic command line attack
+  Scenario:
+    When I launch a "generic" attack with:
+      """
+      vuln-00-runner
+      """
+    Then the output should contain:
+      """
+      Attack Successful
+      """


### PR DESCRIPTION
This commit includes a new webgoat directory under the examples directory and an example Gauntlt attack file for a lesson in WebGoat - specifically the lesson located at General => Http Basics which I've given the ID of vuln-00.  This should be the first of 44+ WebGoat attack files done as part of a case study for CS 361 at the University of Texas during the Fall 2015 semester.  This will stay as a stub until the due date passes when the complete implementation will be in a following PR.

I am the professor for that class.

-- Matt Tesauro